### PR TITLE
fix: store nginx backups outside sites-enabled

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -145,8 +145,9 @@ ensure_single_include_line() {
 	local file_path="$1"
 	local include_line="$2"
 
-	# Backup original once per run
-	cp "$file_path" "${file_path}.backup.$(date +%Y%m%d_%H%M%S)" 2>/dev/null || true
+	# Backup original to a separate directory (not sites-enabled, which nginx auto-loads)
+	mkdir -p "${INSTALL_DIR}/nginx"
+	cp "$file_path" "${INSTALL_DIR}/nginx/$(basename "$file_path").backup.$(date +%Y%m%d_%H%M%S)" 2>/dev/null || true
 
 	# Remove all old markers and include lines (also catches stray variants)
 	sed -i '/# Albert Sandbox Configs/d' "$file_path"
@@ -171,7 +172,9 @@ ensure_client_max_body_size() {
 	local file_path="$1"
 	local setting_line="client_max_body_size 0;"
 
-	cp "$file_path" "${file_path}.backup.$(date +%Y%m%d_%H%M%S)" 2>/dev/null || true
+	# Backup original to a separate directory (not sites-enabled, which nginx auto-loads)
+	mkdir -p "${INSTALL_DIR}/nginx"
+	cp "$file_path" "${INSTALL_DIR}/nginx/$(basename "$file_path").backup.$(date +%Y%m%d_%H%M%S)" 2>/dev/null || true
 
 	awk -v cfg_line="$setting_line" '
 		BEGIN { inserted=0 }


### PR DESCRIPTION
## Summary
- Nginx backup files created by `install.sh` were placed directly in `/etc/nginx/sites-enabled/`, causing nginx to load them as config files and fail with `duplicate default server` error
- Backups are now stored in `$INSTALL_DIR/nginx/` (`/opt/albert-ai-sandbox-manager/nginx/`) instead

## Root cause
The functions `ensure_single_include_line` and `ensure_client_max_body_size` both created timestamped backup copies next to the original file. Since nginx auto-loads all files in `sites-enabled/`, the backup was parsed as a second server block with `default_server`, preventing nginx from starting.

## Test plan
- [x] Fresh install on Debian 12 host with `bash install.sh`
- [x] All services running (nginx, docker, albert-container-manager)
- [x] Health check returns `{"status":"ok","docker":"up"}`
- [x] Sandbox create/delete lifecycle works end-to-end
- [x] noVNC desktop accessible via nginx reverse proxy
- [x] No stray backup files in `/etc/nginx/sites-enabled/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)