### PR TITLE
Security hardening for sandbox-1.novista.ch and the albert-ai-sandbox 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Python bytecode / caches
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Virtualenvs
+venv/
+.venv/
+env/
+
+# Local scratch / context files (audits, notes, ad-hoc dumps)
+.context/
+
+# Editor / OS
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Runtime / install artifacts
+data/
+config/container-registry.json
+nginx/*.backup.*

--- a/docker/file_service.py
+++ b/docker/file_service.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 
+import hmac
+import mimetypes
 import os
 import uuid
-import mimetypes
 from pathlib import Path
 from flask import Flask, request, jsonify, send_file
 
 UPLOAD_DIR = "/tmp/albert-files"
 DEFAULT_PORT = int(os.environ.get("FILE_SERVICE_PORT", "4000"))
+# Bind 0.0.0.0 inside the container so Docker's port-publishing can reach
+# the service. Host-side isolation is handled one layer up by
+# `docker run -p 127.0.0.1:<host>:4000` in albert-ai-sandbox-manager.sh,
+# which limits the exposed port to the host loopback. The bearer token
+# below is the real authentication layer.
+BIND_HOST = os.environ.get("FILE_SERVICE_BIND_HOST", "0.0.0.0")
+FILE_SERVICE_TOKEN = os.environ.get("FILE_SERVICE_TOKEN", "").strip()
 
 app = Flask(__name__)
 
@@ -15,11 +23,37 @@ app = Flask(__name__)
 def ensure_upload_dir():
     try:
         os.makedirs(UPLOAD_DIR, exist_ok=True)
-        # Make it world-writable as container may run different users
-        os.chmod(UPLOAD_DIR, 0o777)
+        os.chmod(UPLOAD_DIR, 0o755)
     except Exception:
-        # Ignore chmod failures on some FS
         pass
+
+
+def _extract_bearer():
+    auth = request.headers.get("Authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return None
+    return auth.split(None, 1)[1].strip()
+
+
+def require_token():
+    # Auth is optional: if no FILE_SERVICE_TOKEN is configured, the service
+    # runs without authentication (legacy behaviour). When a token is set
+    # via the env variable it is enforced on every protected endpoint.
+    if not FILE_SERVICE_TOKEN:
+        return None
+    provided = _extract_bearer()
+    if not provided or not hmac.compare_digest(provided, FILE_SERVICE_TOKEN):
+        return jsonify({"error": "Missing or invalid Authorization header"}), 401
+    return None
+
+
+def _resolve_safe_path(path: str):
+    """Resolve a path and ensure it stays inside UPLOAD_DIR. Returns real_path or None."""
+    real_upload = os.path.realpath(UPLOAD_DIR)
+    real_path = os.path.realpath(path)
+    if real_path != real_upload and not real_path.startswith(real_upload + os.sep):
+        return None
+    return real_path
 
 
 @app.get("/health")
@@ -29,6 +63,10 @@ def health():
 
 @app.post("/upload")
 def upload_file():
+    auth_err = require_token()
+    if auth_err:
+        return auth_err
+
     ensure_upload_dir()
 
     if "file" not in request.files:
@@ -38,15 +76,18 @@ def upload_file():
     if file.filename is None or file.filename == "":
         return jsonify({"error": "No selected file"}), 400
 
-    ext = Path(file.filename).suffix  # includes leading dot or empty string
+    ext = Path(file.filename).suffix
     new_name = f"{uuid.uuid4()}{ext}"
     dest_path = os.path.join(UPLOAD_DIR, new_name)
 
+    # Defense-in-depth: ensure dest cannot escape UPLOAD_DIR even if uuid/ext were abused.
+    if _resolve_safe_path(dest_path) is None:
+        return jsonify({"error": "Invalid destination path"}), 400
+
     try:
         file.save(dest_path)
-        # relax permissions; directory already 777
         try:
-            os.chmod(dest_path, 0o666)
+            os.chmod(dest_path, 0o644)
         except Exception:
             pass
         return jsonify({"path": dest_path}), 201
@@ -56,21 +97,32 @@ def upload_file():
 
 @app.get("/download")
 def download_file():
+    auth_err = require_token()
+    if auth_err:
+        return auth_err
+
     path = request.args.get("path")
     if not path:
         return jsonify({"error": "Missing query parameter 'path' with full file path"}), 400
 
-    # Expect absolute path per requirement
     if not os.path.isabs(path):
         return jsonify({"error": "Provided path must be an absolute path"}), 400
 
-    if not os.path.exists(path) or not os.path.isfile(path):
+    real_path = _resolve_safe_path(path)
+    if real_path is None:
+        return jsonify({"error": "Access denied: path outside upload directory"}), 403
+
+    if not os.path.exists(real_path) or not os.path.isfile(real_path):
         return jsonify({"error": "File not found"}), 404
 
-    # Try to guess a content-type
-    mime, _ = mimetypes.guess_type(path)
+    mime, _ = mimetypes.guess_type(real_path)
     try:
-        return send_file(path, mimetype=mime or "application/octet-stream", as_attachment=False, conditional=True)
+        return send_file(
+            real_path,
+            mimetype=mime or "application/octet-stream",
+            as_attachment=False,
+            conditional=True,
+        )
     except Exception as e:
         return jsonify({"error": f"Failed to read file: {e}"}), 500
 
@@ -78,8 +130,7 @@ def download_file():
 def main():
     ensure_upload_dir()
     port = int(os.environ.get("FILE_SERVICE_PORT", DEFAULT_PORT))
-    # Bind to all interfaces
-    app.run(host="0.0.0.0", port=port)
+    app.run(host=BIND_HOST, port=port)
 
 
 if __name__ == "__main__":

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -3,10 +3,24 @@
 echo "Starting VNC server with 1280x720 resolution..."
 rm -rf /tmp/.X*-lock /tmp/.X11-unix
 
-# Automatically set password "albert"
+# VNC password: prefer env VNC_PASSWORD; otherwise generate a random one.
+# tightvnc truncates passwords at 8 chars, so we cap/generate accordingly.
+if [ -z "${VNC_PASSWORD}" ]; then
+	VNC_PASSWORD="$(openssl rand -base64 9 | tr -dc 'A-Za-z0-9' | head -c 8)"
+	echo "Generated random VNC password (length 8)."
+fi
+VNC_PASSWORD_TRUNC="$(printf '%s' "${VNC_PASSWORD}" | cut -c1-8)"
+export VNC_PASSWORD_TRUNC
+
 su - ubuntu -c "mkdir -p ~/.vnc"
-su - ubuntu -c "echo 'albert' | vncpasswd -f > ~/.vnc/passwd"
+su - ubuntu -c "printf '%s' \"${VNC_PASSWORD_TRUNC}\" | vncpasswd -f > ~/.vnc/passwd"
 su - ubuntu -c "chmod 600 ~/.vnc/passwd"
+
+# File service token: must be provided via env; otherwise file service refuses requests.
+if [ -z "${FILE_SERVICE_TOKEN}" ]; then
+	echo "Warning: FILE_SERVICE_TOKEN not set; file service will reject all requests." >&2
+fi
+export FILE_SERVICE_TOKEN
 
 # Start VNC with 1280x720 resolution
 su - ubuntu -c 'tightvncserver :1 -geometry 1280x720 -depth 24 -rfbauth ~/.vnc/passwd' &

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,11 @@ echo -e "${YELLOW}Configuring nginx...${NC}"
 DEFAULT_SITE="${NGINX_ENABLED_DIR}/default"
 INCLUDE_LINE="include ${NGINX_CONF_DIR}/albert-*.conf;"
 
-# Helper to ensure exactly one include line after 'server_name _;' using awk (robust vs sed newlines)
+# Helper to ensure the albert include line is present after every relevant
+# server_name directive. "Relevant" = the default HTTP block (server_name _;)
+# AND any certbot-managed TLS block (server_name ...; # managed by Certbot).
+# Both must include albert-*.conf so /<container>/ and /manager/ work over
+# HTTPS as well as HTTP.
 ensure_single_include_line() {
 	local file_path="$1"
 	local include_line="$2"
@@ -154,17 +158,15 @@ ensure_single_include_line() {
 	sed -i '/# ALBERT Sandbox Configs/d' "$file_path"
 	sed -i '/include .*albert-\*.conf;/d' "$file_path"
 
-	# Insert a single include block after the first server_name _; line
+	# Insert an include block after each matching server_name line.
 	awk -v inc_line="$include_line" '
-		BEGIN { inserted=0 }
 		{
 			print $0
-			if (!inserted && $0 ~ /server_name[[:space:]]+_;/) {
+			if ($0 ~ /server_name[[:space:]]+_;/ || $0 ~ /server_name[[:space:]].*managed by Certbot/) {
 				print "\t# Albert Sandbox Configs"
 				print "\t" inc_line
-				inserted=1
 			}
-	}
+		}
 	' "$file_path" > "${file_path}.tmp" && mv "${file_path}.tmp" "$file_path"
 }
 
@@ -176,13 +178,14 @@ ensure_client_max_body_size() {
 	mkdir -p "${INSTALL_DIR}/nginx"
 	cp "$file_path" "${INSTALL_DIR}/nginx/$(basename "$file_path").backup.$(date +%Y%m%d_%H%M%S)" 2>/dev/null || true
 
+	# Drop prior occurrences so this is idempotent across re-runs.
+	sed -i '/^[[:space:]]*client_max_body_size[[:space:]]\+0;/d' "$file_path"
+
 	awk -v cfg_line="$setting_line" '
-		BEGIN { inserted=0 }
 		{
 			print $0
-			if (!inserted && $0 ~ /server_name[[:space:]]+_;/) {
+			if ($0 ~ /server_name[[:space:]]+_;/ || $0 ~ /server_name[[:space:]].*managed by Certbot/) {
 				print "\t" cfg_line
-				inserted=1
 			}
 		}
 	' "$file_path" > "${file_path}.tmp" && mv "${file_path}.tmp" "$file_path"
@@ -190,22 +193,28 @@ ensure_client_max_body_size() {
 
 if [ -f "${DEFAULT_SITE}" ]; then
 	echo -e "${YELLOW}Reconciling nginx default site includes...${NC}"
+
+	# Count target server_name lines (the plain default + any certbot TLS block).
+	target_count=$(grep -cE 'server_name[[:space:]]+_;|server_name[[:space:]].*managed by Certbot' "${DEFAULT_SITE}" 2>/dev/null || true)
+	target_count=${target_count:-0}
 	include_count=$(grep -c "include .*albert-\\*.conf;" "${DEFAULT_SITE}" 2>/dev/null || true)
 	include_count=${include_count:-0}
 
-	if [ "${include_count}" -ne 1 ]; then
+	if [ "${include_count}" -ne "${target_count}" ] || [ "${target_count}" -eq 0 ]; then
 		ensure_single_include_line "${DEFAULT_SITE}" "${INCLUDE_LINE}"
-		echo -e "${GREEN}✓ Nginx include normalized to a single line${NC}"
+		echo -e "${GREEN}✓ Nginx includes normalized (target=${target_count})${NC}"
 	else
-		echo -e "${GREEN}✓ Nginx include already present (1)${NC}"
+		echo -e "${GREEN}✓ Nginx include already present in all ${include_count} server blocks${NC}"
 	fi
 
-	if ! grep -Eq '^[[:space:]]*client_max_body_size[[:space:]]+0;' "${DEFAULT_SITE}"; then
+	cmbs_count=$(grep -cE '^[[:space:]]*client_max_body_size[[:space:]]+0;' "${DEFAULT_SITE}" 2>/dev/null || true)
+	cmbs_count=${cmbs_count:-0}
+	if [ "${cmbs_count}" -ne "${target_count}" ]; then
 		echo -e "${YELLOW}Adding client_max_body_size 0 to nginx default site...${NC}"
 		ensure_client_max_body_size "${DEFAULT_SITE}"
-		echo -e "${GREEN}✓ client_max_body_size configured for default site${NC}"
+		echo -e "${GREEN}✓ client_max_body_size configured in ${target_count} block(s)${NC}"
 	else
-		echo -e "${GREEN}✓ client_max_body_size already present in default site${NC}"
+		echo -e "${GREEN}✓ client_max_body_size already present in all server blocks${NC}"
 	fi
 fi
 
@@ -355,16 +364,19 @@ else
 	echo -e "${RED}✗ Nginx is not running${NC}"
 fi
 
-# Check final nginx configuration
+# Check final nginx configuration: one include per relevant server block
+# (default '_' block plus any certbot-managed TLS block).
 echo -e "${YELLOW}Checking final nginx configuration...${NC}"
 include_count=$(grep -c "include.*albert-\*.conf;" /etc/nginx/sites-enabled/default 2>/dev/null || true)
 include_count=${include_count:-0}
-if [ "$include_count" -eq 1 ]; then
-	echo -e "${GREEN}✓ Nginx include correctly configured (1 include found)${NC}"
-elif [ "$include_count" -gt 1 ]; then
-	echo -e "${RED}⚠ Warning: Multiple includes found ($include_count)${NC}"
-	echo -e "${YELLOW}  Run: nano /etc/nginx/sites-enabled/default${NC}"
-	echo -e "${YELLOW}  and remove duplicate include lines${NC}"
+target_count=$(grep -cE 'server_name[[:space:]]+_;|server_name[[:space:]].*managed by Certbot' /etc/nginx/sites-enabled/default 2>/dev/null || true)
+target_count=${target_count:-0}
+if [ "$include_count" -eq "$target_count" ] && [ "$target_count" -gt 0 ]; then
+	echo -e "${GREEN}✓ Nginx include correctly configured (${include_count}/${target_count} blocks)${NC}"
+elif [ "$include_count" -lt "$target_count" ]; then
+	echo -e "${YELLOW}⚠ Missing include(s): ${include_count}/${target_count} blocks covered${NC}"
+elif [ "$include_count" -gt "$target_count" ]; then
+	echo -e "${YELLOW}⚠ Extra includes found: ${include_count} vs ${target_count} target blocks${NC}"
 else
 	echo -e "${YELLOW}⚠ No nginx include found${NC}"
 fi

--- a/install.sh
+++ b/install.sh
@@ -240,6 +240,7 @@ ExecStart=/usr/bin/env bash -c '[ -x /opt/albert-ai-sandbox-manager/venv/bin/pyt
 Restart=on-failure
 RestartSec=5
 Environment=MANAGER_PORT=5001
+Environment=MANAGER_BIND_HOST=127.0.0.1
 Environment=MANAGER_DB_PATH=/opt/albert-ai-sandbox-manager/data/manager.db
 Environment=MANAGER_DATA_DIR=/opt/albert-ai-sandbox-manager/data/containers
 # Optional: restrict privileges a bit (comment out if causing issues)
@@ -304,7 +305,11 @@ if [ ! -f "$MANAGER_NGX_CONF" ]; then
 cat > "$MANAGER_NGX_CONF" <<'EOF'
 # Reverse proxy for ALBERT Container Manager REST API
 location /manager/ {
-	proxy_pass http://localhost:5001/;
+	# Rate-limit: zone defined in /etc/nginx/conf.d/albert-security.conf
+	# (setup-tls.sh installs it). If the zone is missing, nginx -t will fail;
+	# make sure setup-tls.sh ran before reloading nginx.
+	limit_req zone=albert_manager burst=20 nodelay;
+	proxy_pass http://127.0.0.1:5001/;
 	proxy_http_version 1.1;
 	proxy_set_header Upgrade $http_upgrade;
 	proxy_set_header Connection "upgrade";

--- a/nginx/albert-security.conf
+++ b/nginx/albert-security.conf
@@ -1,0 +1,23 @@
+# Albert sandbox: global nginx security hardening.
+# Installed to /etc/nginx/conf.d/albert-security.conf by scripts/setup-tls.sh.
+# Takes effect for every server block on this host because it's in the http context.
+
+server_tokens off;
+
+# Rate-limit zones. Used by /manager/ (burst=20) and other sensitive routes.
+limit_req_zone $binary_remote_addr zone=albert_manager:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=albert_general:10m rate=30r/s;
+limit_req_status 429;
+
+# CSP is intentionally permissive because noVNC uses inline/eval JavaScript.
+# A stricter CSP requires a separate audit of the noVNC frontend.
+map $sent_http_content_type $albert_csp {
+    default "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:; img-src 'self' data: blob:; connect-src 'self' wss: ws:; frame-ancestors 'self'";
+}
+
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+add_header Content-Security-Policy $albert_csp always;

--- a/scripts/albert-ai-sandbox-manager.sh
+++ b/scripts/albert-ai-sandbox-manager.sh
@@ -868,12 +868,13 @@ start_container() {
 			fi
 			return 1
 		fi
+		local base
+		base=$(public_base_url)
 		if [ -n "$JSON_MODE" ]; then
-			local hostip=$(hostname -I | awk '{print $1}')
-			json_emit '{result:"started", name:$n, url:($h+"/"+$n+"/"), host:$h}' --arg n "$name" --arg h "http://$hostip"
+			json_emit '{result:"started", name:$n, url:($h+"/"+$n+"/"), host:$h}' --arg n "$name" --arg h "$base"
 		elif [ -z "$QUIET" ]; then
 			echo -e "${GREEN}Container '$name' started${NC}"
-			echo -e "${GREEN}URL: http://$(hostname -I | awk '{print $1}')/${name}/${NC}"
+			echo -e "${GREEN}URL: ${base}/${name}/${NC}"
 		fi
         else
                 if [ -n "$JSON_MODE" ]; then
@@ -1034,7 +1035,8 @@ show_single_status() {
 			stats=""
 		fi
 	fi
-	local hostip=$(hostname -I | awk '{print $1}')
+	local base
+	base=$(public_base_url)
         if [ "$mode" = "json" ] || [ -n "$JSON_MODE" ]; then
                 jq -n \
                         --arg name "$name" \
@@ -1047,8 +1049,8 @@ show_single_status() {
 			--arg filesvc "$filesvc_port" \
 			--arg stats "$stats" \
 			--arg ownerHash "$OWNER_KEY_HASH_ENV" \
-			--arg host "$hostip" \
-                        '{name:$name,status:$status,created:$created,persistent:$persistent,ownerHash:$ownerHash,ports:{novnc:$novnc,vnc:$vnc,mcphub:$mcphub,filesvc:$filesvc},resources:$stats,urls:{desktop:("http://"+$host+"/"+$name+"/"), mcphub:("http://"+$host+"/"+$name+"/mcphub/mcp"), files:("http://"+$host+"/"+$name+"/files/")}}'
+			--arg host "$base" \
+                        '{name:$name,status:$status,created:$created,persistent:$persistent,ownerHash:$ownerHash,ports:{novnc:$novnc,vnc:$vnc,mcphub:$mcphub,filesvc:$filesvc},resources:$stats,urls:{desktop:($host+"/"+$name+"/"), mcphub:($host+"/"+$name+"/mcphub/mcp"), files:($host+"/"+$name+"/files/")}}'
                 __ALBERT_JSON_EMITTED=1
         else
                 echo -e "${BLUE}Container: ${NC}$name"
@@ -1062,7 +1064,7 @@ show_single_status() {
 		else
 			echo -e "${BLUE}Docker Status: ${RED}Stopped${NC}"
 		fi
-		echo -e "${BLUE}URL: ${NC}http://${hostip}/${name}/"
+		echo -e "${BLUE}URL: ${NC}${base}/${name}/"
 	fi
 }
 

--- a/scripts/albert-ai-sandbox-manager.sh
+++ b/scripts/albert-ai-sandbox-manager.sh
@@ -295,16 +295,19 @@ PY
 
 lookup_api_key_id_python() {
 	local hash="$1"
-	python3 - <<PY 2>/dev/null || true
+	# Pass lookup hash as env var to avoid shell-to-python string interpolation.
+	# Quoted heredoc ('PY') prevents bash variable expansion inside the heredoc body.
+	LOOKUP_HASH="$hash" python3 - <<'PY' 2>/dev/null || true
 import sqlite3, os
-db=os.environ.get('DB_PATH')
+db = os.environ.get('DB_PATH')
+lookup_hash = os.environ.get('LOOKUP_HASH', '')
 if not db or not os.path.exists(db):
-		print("")
-		raise SystemExit
-con=sqlite3.connect(db)
-cur=con.cursor()
-cur.execute("SELECT id FROM api_keys WHERE key_hash=? LIMIT 1", ("$hash",))
-r=cur.fetchone()
+    print("")
+    raise SystemExit
+con = sqlite3.connect(db)
+cur = con.cursor()
+cur.execute("SELECT id FROM api_keys WHERE key_hash=? LIMIT 1", (lookup_hash,))
+r = cur.fetchone()
 print(r[0] if r else "")
 con.close()
 PY

--- a/scripts/albert-ai-sandbox-manager.sh
+++ b/scripts/albert-ai-sandbox-manager.sh
@@ -40,6 +40,23 @@ resolve_db_path() {
 resolve_db_path
 export DB_PATH  # ensure python heredocs can read it
 
+# Returns the public base URL used in API responses and banner output.
+# - If ALBERT_PUBLIC_URL is set (e.g. https://sandbox-1.novista.ch), it is
+#   returned verbatim with a trailing slash stripped so concatenations like
+#   "$base/$name/" stay clean.
+# - Otherwise we fall back to the legacy behaviour: http:// + primary IPv4
+#   from `hostname -I`. This keeps installations without a public FQDN
+#   working unchanged.
+public_base_url() {
+	if [ -n "${ALBERT_PUBLIC_URL:-}" ]; then
+		printf '%s' "${ALBERT_PUBLIC_URL%/}"
+		return 0
+	fi
+	local hostip
+	hostip=$(hostname -I | awk '{print $1}')
+	printf 'http://%s' "$hostip"
+}
+
 # Extended modes
 JSON_MODE="${ALBERT_JSON:-}"          # set to any non-empty for JSON output
 OWNER_KEY_HASH_ENV="${ALBERT_OWNER_KEY_HASH:-}"  # passed in by REST service
@@ -665,21 +682,33 @@ create_container() {
 		LABEL_ARGS+=(--label "albert.apikey_hash=$OWNER_KEY_HASH_ENV")
 	fi
 
+	# Generate per-container secrets.
+	# VNC: tightvncserver truncates to 8 chars, so we stay inside that limit.
+	# File service token: 32 hex chars (128 bits).
+	local vnc_password
+	vnc_password="$(openssl rand -base64 12 | tr -dc 'A-Za-z0-9' | head -c 8)"
+	local filesvc_token
+	filesvc_token="$(openssl rand -hex 16)"
+	trace_log "generated per-container credentials name='$name'"
+
 	# Create Docker container
+	# Port publishing is bound to 127.0.0.1 so the container ports are only
+	# reachable via the local nginx reverse proxy, not from the public internet.
         docker run -d \
                 "${LABEL_ARGS[@]}" \
                 --name "$name" \
                 --restart unless-stopped \
                 --cap-add=SYS_ADMIN \
                 --security-opt seccomp=unconfined \
-		-p ${novnc_port}:6081 \
-		-p ${vnc_port}:5901 \
-		-p ${mcphub_port}:3000 \
-		-p ${filesvc_port}:4000 \
+		-p 127.0.0.1:${novnc_port}:6081 \
+		-p 127.0.0.1:${vnc_port}:5901 \
+		-p 127.0.0.1:${mcphub_port}:3000 \
+		-p 127.0.0.1:${filesvc_port}:4000 \
 		-e VNC_PORT=5901 \
 		-e NO_VNC_PORT=6081 \
 		-e MCP_HUB_PORT=3000 \
 		-e FILE_SERVICE_PORT=4000 \
+		-e VNC_PASSWORD="$vnc_password" \
 		-v ${name}_data:/home/ubuntu \
                 --shm-size=2g \
                 "$DOCKER_IMAGE" >/dev/null
@@ -701,16 +730,17 @@ create_container() {
 		# Register in registry
 		local persistent_val="false"
 		[ -n "$PERSISTENT" ] && persistent_val="true"
-		add_to_registry "$name" "$novnc_port" "$vnc_port" "$mcphub_port" "$filesvc_port" "$persistent_val"
+		add_to_registry "$name" "$novnc_port" "$vnc_port" "$mcphub_port" "$filesvc_port" "$persistent_val" "$vnc_password" "$filesvc_token"
 
 		# Insert mapping into containers table (ignore if already exists)
 		CONTAINER_ID=$(docker inspect -f '{{ .Id }}' "$name" 2>/dev/null || true)
 		if [ -n "$CONTAINER_ID" ] && [ -n "$API_KEY_DB_ID" ]; then
 			sqlite3 "$DB_PATH" "INSERT OR IGNORE INTO containers(api_key_id, container_id, name, image, created_at) VALUES($API_KEY_DB_ID,'$CONTAINER_ID','$name','$DOCKER_IMAGE', strftime('%s','now'));" 2>/dev/null || true
 		fi
-		
-		# Configure nginx (includes file service)
-		create_nginx_config "$name" "$novnc_port" "$mcphub_port" "$filesvc_port"
+
+		# Configure nginx (includes file service). VNC password is embedded
+		# into the redirect URL so noVNC autoconnect still works per-container.
+		create_nginx_config "$name" "$novnc_port" "$mcphub_port" "$filesvc_port" "$vnc_password"
 		
 		# Create global MCP Hub configuration (only once)
 		if [ ! -f "${NGINX_CONF_DIR}/albert-mcphub-global.conf" ]; then
@@ -719,28 +749,33 @@ create_container() {
 
 		release_lock
 
+		local base
+		base=$(public_base_url)
 		if [ -n "$JSON_MODE" ]; then
-			HOSTIP=$(hostname -I | awk '{print $1}')
-			json_emit '{result:"created", name:$name, ownerHash:$ownerHash, persistent:$persistent, ports:{novnc:$novnc_port,vnc:$vnc_port,mcphub:$mcphub_port,filesvc:$filesvc_port}, urls:{desktop:("http://"+$host+"/"+$name+"/"), mcphub:("http://"+$host+"/"+$name+"/mcphub/mcp"), filesUpload:("http://"+$host+"/"+$name+"/files/upload"), filesDownloadPattern:("http://"+$host+"/"+$name+"/files/download?path=/tmp/albert-files/<uuid.ext>")}}' \
+			json_emit '{result:"created", name:$name, ownerHash:$ownerHash, persistent:$persistent, vncPassword:$vncPassword, fileServiceToken:$fileServiceToken, ports:{novnc:$novnc_port,vnc:$vnc_port,mcphub:$mcphub_port,filesvc:$filesvc_port}, urls:{desktop:($host+"/"+$name+"/"), mcphub:($host+"/"+$name+"/mcphub/mcp"), filesUpload:($host+"/"+$name+"/files/upload"), filesDownloadPattern:($host+"/"+$name+"/files/download?path=/tmp/albert-files/<uuid.ext>")}}' \
 				--arg name "$name" \
 				--arg novnc_port "$novnc_port" \
 				--arg vnc_port "$vnc_port" \
 				--arg mcphub_port "$mcphub_port" \
 				--arg filesvc_port "$filesvc_port" \
 				--arg ownerHash "$OWNER_KEY_HASH_ENV" \
+				--arg vncPassword "$vnc_password" \
+				--arg fileServiceToken "$filesvc_token" \
 				--argjson persistent "$persistent_val" \
-				--arg host "$HOSTIP"
+				--arg host "$base"
 		else
 			echo -e "${GREEN}========================================${NC}"
 			echo -e "${GREEN}Sandbox container created successfully!${NC}"
 			echo -e "${GREEN}========================================${NC}"
 			echo -e "${GREEN}Name: ${name}${NC}"
-			echo -e "${GREEN}DESKTOP: http://$(hostname -I | awk '{print $1}')/${name}/${NC}"
-			echo -e "${GREEN}MCP URL: http://$(hostname -I | awk '{print $1}')/${name}/mcphub/mcp${NC}"
-			echo -e "${GREEN}File Service Upload: http://$(hostname -I | awk '{print $1}')/${name}/files/upload${NC}"
-			echo -e "${GREEN}File Service Download: http://$(hostname -I | awk '{print $1}')/${name}/files/download?path=/tmp/albert-files/<uuid.ext>${NC}"
+			echo -e "${GREEN}DESKTOP: ${base}/${name}/${NC}"
+			echo -e "${GREEN}MCP URL: ${base}/${name}/mcphub/mcp${NC}"
+			echo -e "${GREEN}File Service Upload: ${base}/${name}/files/upload${NC}"
+			echo -e "${GREEN}File Service Download: ${base}/${name}/files/download?path=/tmp/albert-files/<uuid.ext>${NC}"
+			echo -e "${YELLOW}VNC Password: ${vnc_password}${NC}"
+			echo -e "${YELLOW}File Service Token (Bearer): ${filesvc_token}${NC}"
 			echo -e "${YELLOW}MCP Hub Bearer token: albert${NC}"
-			echo -e "${YELLOW}Important: Note the URL - the name is the access protection!${NC}"
+			echo -e "${YELLOW}Important: secrets above are shown once - store them safely.${NC}"
 		fi
         else
                 release_lock

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -42,6 +42,8 @@ add_to_registry() {
 	local mcphub_port=$4
 	local filesvc_port=${5:-}
 	local persistent=${6:-false}
+	local vnc_password=${7:-}
+	local filesvc_token=${8:-}
 
 	init_registry
 
@@ -53,17 +55,20 @@ add_to_registry() {
 			--arg vnc_port "$vnc_port" \
 			--arg mcphub_port "${mcphub_port:-}" \
 			--arg filesvc_port "${filesvc_port:-}" \
+			--arg vnc_password "$vnc_password" \
+			--arg filesvc_token "$filesvc_token" \
 			--arg created "$(date -Iseconds)" \
 			--argjson persistent "$persistent" \
-			'{name: $name, port: $port, vnc_port: $vnc_port, mcphub_port: $mcphub_port, filesvc_port: $filesvc_port, created: $created, persistent: $persistent}')
+			'{name: $name, port: $port, vnc_port: $vnc_port, mcphub_port: $mcphub_port, filesvc_port: $filesvc_port, vnc_password: $vnc_password, filesvc_token: $filesvc_token, created: $created, persistent: $persistent}')
 	else
 		local entry=$(jq -n \
 			--arg name "$name" \
 			--arg port "$port" \
 			--arg vnc_port "$vnc_port" \
+			--arg vnc_password "$vnc_password" \
 			--arg created "$(date -Iseconds)" \
 			--argjson persistent "$persistent" \
-			'{name: $name, port: $port, vnc_port: $vnc_port, created: $created, persistent: $persistent}')
+			'{name: $name, port: $port, vnc_port: $vnc_port, vnc_password: $vnc_password, created: $created, persistent: $persistent}')
 	fi
 
 	jq ". += [$entry]" "$REGISTRY_FILE" > "${REGISTRY_FILE}.tmp" && mv "${REGISTRY_FILE}.tmp" "$REGISTRY_FILE"

--- a/scripts/container_manager_service.py
+++ b/scripts/container_manager_service.py
@@ -55,6 +55,7 @@ DEFAULT_DATA_DIR = BASE_DIR / "data" / "containers"
 
 # Configuration
 PORT = int(os.environ.get("MANAGER_PORT", "5001"))
+BIND_HOST = os.environ.get("MANAGER_BIND_HOST", "127.0.0.1")
 DB_PATH = os.environ.get("MANAGER_DB_PATH", str(DEFAULT_DB_PATH))
 DATA_DIR = os.environ.get("MANAGER_DATA_DIR", str(DEFAULT_DATA_DIR))
 ALLOWED_IMAGES = [i.strip() for i in os.environ.get("MANAGER_ALLOWED_IMAGES", "").split(",") if i.strip()] or None
@@ -306,6 +307,9 @@ def not_found(e):  # pragma: no cover (simple wrapper)
 
 @app.get("/health")
 def health():
+    _, err = require_api_key()
+    if err:
+        return err
     docker_status = "up" if docker_info_available() else "down"
     return jsonify({"status": "ok", "docker": docker_status})
 
@@ -476,7 +480,7 @@ def delete_container(cid: str):
 # --- Main ------------------------------------------------------------------
 
 def main():
-    app.run(host="0.0.0.0", port=PORT)
+    app.run(host=BIND_HOST, port=PORT)
 
 if __name__ == "__main__":
     main()

--- a/scripts/container_manager_service.py
+++ b/scripts/container_manager_service.py
@@ -161,6 +161,11 @@ def _extract_script_metadata(payload: Any) -> Dict[str, Any]:
         result["status"] = status
     if "persistent" in payload:
         result["persistent"] = payload["persistent"]
+    # Per-container secrets (only present in create responses)
+    if payload.get("vncPassword"):
+        result["vncPassword"] = payload["vncPassword"]
+    if payload.get("fileServiceToken"):
+        result["fileServiceToken"] = payload["fileServiceToken"]
     return result
 
 # --- Database helpers ------------------------------------------------------

--- a/scripts/nginx-manager.sh
+++ b/scripts/nginx-manager.sh
@@ -182,7 +182,9 @@ _ensure_include_and_reload() {
     nginx -t && systemctl reload nginx
 }
 
-# Internal: ensure exactly one include line exists after server_name _;
+# Internal: ensure the albert include line is present in every relevant
+# server block (default '_' block and any certbot-managed TLS block). This
+# mirrors the logic in install.sh so per-container nginx writes stay in sync.
 _ensure_single_include_line() {
     local file_path="$1"
     local include_line="$2"
@@ -192,36 +194,42 @@ _ensure_single_include_line() {
     sed -i '/# ALBERT Sandbox Configs/d' "$file_path"
     sed -i '/include .*albert-\*.conf;/d' "$file_path"
 
-    # Insert once after server_name _; using awk to avoid sed escape quirks
+    # Insert after every matching server_name line.
     awk -v inc_line="$include_line" '
-        BEGIN { inserted=0 }
         {
             print $0
-            if (!inserted && $0 ~ /server_name[[:space:]]+_;/) {
+            if ($0 ~ /server_name[[:space:]]+_;/ || $0 ~ /server_name[[:space:]].*managed by Certbot/) {
                 print "\t# Albert Sandbox Configs"
                 print "\t" inc_line
-                inserted=1
             }
         }
     ' "$file_path" > "${file_path}.tmp" && mv "${file_path}.tmp" "$file_path"
 }
 
-# Tidies duplicate include lines in default site
+# Tidies include lines in the default site. After every operation we expect
+# exactly one include per target server block (1 for plain HTTP, 2 once TLS
+# is enabled). Only rewrite if the count diverges from that target. Warnings
+# are written to stderr so they do not contaminate JSON stdout consumed by
+# container_manager_service.
 cleanup_nginx_includes() {
     local config_file="${NGINX_ENABLED_DIR}/default"
-    # Generic regex pattern to match any albert-*.conf include lines
     local pattern='include .*albert-\*.conf;'
 
-    local count=$(grep -c "$pattern" "$config_file" 2>/dev/null || echo 0)
-    if [ "$count" -gt 1 ]; then
-        echo -e "${YELLOW}Cleaning up duplicate nginx includes (found: $count)...${NC}"
-        cp "$config_file" "${config_file}.backup.$(date +%Y%m%d_%H%M%S)"
-        # Remove all our include markers/lines
-        sed -i '/# Albert Sandbox Configs/d' "$config_file"
-        sed -i '/# ALBERT Sandbox Configs/d' "$config_file"
-        sed -i "/$pattern/d" "$config_file"
-        # Add a single include line back using helper
-        _ensure_single_include_line "$config_file" "include ${NGINX_CONF_DIR}/albert-*.conf;"
-        echo -e "${GREEN}✓ Nginx includes cleaned up${NC}"
+    local count
+    count=$(grep -c "$pattern" "$config_file" 2>/dev/null || echo 0)
+    local target
+    target=$(grep -cE 'server_name[[:space:]]+_;|server_name[[:space:]].*managed by Certbot' "$config_file" 2>/dev/null || echo 0)
+
+    if [ "$target" -eq 0 ]; then
+        return 0
     fi
+    if [ "$count" -eq "$target" ]; then
+        return 0
+    fi
+    echo "Reconciling nginx includes (have=$count, want=$target)..." >&2
+    # Never place backups inside sites-enabled: nginx globs that directory.
+    local backup_dir="/opt/albert-ai-sandbox-manager/nginx/backups"
+    mkdir -p "$backup_dir"
+    cp "$config_file" "$backup_dir/default.backup.$(date +%Y%m%d_%H%M%S)"
+    _ensure_single_include_line "$config_file" "include ${NGINX_CONF_DIR}/albert-*.conf;"
 }

--- a/scripts/nginx-manager.sh
+++ b/scripts/nginx-manager.sh
@@ -13,13 +13,22 @@ create_nginx_config() {
     local novnc_port="$2"
     local mcphub_port="${3:-}"
     local filesvc_port="${4:-}"
+    local vnc_password="${5:-}"
 
     local cfg="${NGINX_CONF_DIR}/albert-${container_name}.conf"
+
+    # URL-encode the VNC password for safe inclusion in the redirect query string.
+    local vnc_password_enc
+    if [ -n "$vnc_password" ] && command -v python3 >/dev/null 2>&1; then
+        vnc_password_enc=$(VNC_PW="$vnc_password" python3 -c 'import os,urllib.parse;print(urllib.parse.quote(os.environ["VNC_PW"],safe=""))')
+    else
+        vnc_password_enc="$vnc_password"
+    fi
 
     cat > "$cfg" <<EOF
 # Auto-redirect to noVNC with correct websocket path
 location = /${container_name}/ {
-    return 301 /${container_name}/vnc.html?path=${container_name}/websockify&password=albert&autoconnect=true&resize=scale;
+    return 301 /${container_name}/vnc.html?path=${container_name}/websockify&password=${vnc_password_enc}&autoconnect=true&resize=scale;
 }
 
 # Main proxy for noVNC interface

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -173,6 +173,27 @@ APT::Periodic::AutocleanInterval "7";
 AU
 systemctl enable --now unattended-upgrades >/dev/null
 
+# --- Step h: ALBERT_PUBLIC_URL drop-in -------------------------------------
+# Make the public FQDN available to the manager service so REST responses
+# carry https://<fqdn>/... URLs instead of http://<ip>/... . install.sh
+# doesn't know the FQDN, so we place the override here as a systemd drop-in.
+say "Configuring ALBERT_PUBLIC_URL for manager service..."
+DROPIN_DIR="/etc/systemd/system/albert-container-manager.service.d"
+DROPIN_FILE="${DROPIN_DIR}/public-url.conf"
+mkdir -p "$DROPIN_DIR"
+backup "$DROPIN_FILE"
+cat > "$DROPIN_FILE" <<EOF
+[Service]
+Environment=ALBERT_PUBLIC_URL=https://${FQDN}
+EOF
+systemctl daemon-reload
+if systemctl is-active --quiet albert-container-manager.service; then
+	systemctl restart albert-container-manager.service
+	say "Restarted albert-container-manager with ALBERT_PUBLIC_URL=https://${FQDN}"
+else
+	say "albert-container-manager not active yet; drop-in will take effect on next start."
+fi
+
 # --- Summary ---------------------------------------------------------------
 say "============================================================"
 say "Host hardening complete."

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Albert sandbox host hardening: TLS (Let's Encrypt), firewall, security
+# headers, fail2ban, SSH hardening, unattended-upgrades.
+#
+# Run ONCE per host as root, before/after install.sh. Idempotent: every step
+# is safe to re-run. Reads FQDN and ADMIN_EMAIL from arguments or environment.
+#
+#   sudo FQDN=sandbox-1.novista.ch ADMIN_EMAIL=admin@novista.ch bash setup-tls.sh
+#   sudo bash setup-tls.sh --fqdn sandbox-1.novista.ch --email admin@novista.ch
+#
+# The script deliberately does NOT start or modify the albert-container-manager
+# service. Run install.sh after this script finishes.
+
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+say() { echo -e "${GREEN}[setup-tls]${NC} $*"; }
+warn() { echo -e "${YELLOW}[setup-tls]${NC} $*" >&2; }
+die() { echo -e "${RED}[setup-tls]${NC} $*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || die "Must be run as root."
+
+FQDN="${FQDN:-}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-}"
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--fqdn) FQDN="$2"; shift 2 ;;
+		--email) ADMIN_EMAIL="$2"; shift 2 ;;
+		-h|--help)
+			grep '^#' "$0" | sed 's/^# \{0,1\}//'
+			exit 0 ;;
+		*) die "Unknown argument: $1" ;;
+	esac
+done
+[[ -n "$FQDN" ]] || die "FQDN not set (use --fqdn or FQDN env)."
+[[ -n "$ADMIN_EMAIL" ]] || die "ADMIN_EMAIL not set (use --email or ADMIN_EMAIL env)."
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "${SCRIPT_DIR}/.." && pwd )"
+SECURITY_CONF_SRC="${REPO_ROOT}/nginx/albert-security.conf"
+SECURITY_CONF_DST="/etc/nginx/conf.d/albert-security.conf"
+BACKUP_DIR="/root/albert-hardening/backups/$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$BACKUP_DIR"
+
+backup() {
+	local src="$1"
+	[[ -e "$src" ]] || return 0
+	install -D "$src" "${BACKUP_DIR}${src}"
+}
+
+# --- Step a: packages ------------------------------------------------------
+say "Installing required packages (certbot, fail2ban, ufw, unattended-upgrades)..."
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq \
+	certbot python3-certbot-nginx \
+	fail2ban ufw unattended-upgrades
+
+# --- Step b: ufw firewall --------------------------------------------------
+# SSH rule is added BEFORE enabling to prevent lockout.
+say "Configuring ufw firewall..."
+ufw allow 22/tcp comment 'ssh' >/dev/null
+ufw allow 80/tcp comment 'http (acme + redirect)' >/dev/null
+ufw allow 443/tcp comment 'https' >/dev/null
+ufw default deny incoming >/dev/null
+ufw default allow outgoing >/dev/null
+if ! ufw status | grep -q '^Status: active'; then
+	echo 'y' | ufw enable >/dev/null
+fi
+say "ufw rules:"
+ufw status verbose | sed 's/^/    /'
+
+# --- Step c: Let's Encrypt certificate -------------------------------------
+# We need nginx running on port 80 so certbot --nginx can solve HTTP-01.
+say "Ensuring nginx is running for ACME HTTP-01 challenge..."
+systemctl enable --now nginx
+nginx -t
+
+CERT_LIVE="/etc/letsencrypt/live/${FQDN}/fullchain.pem"
+if [[ -f "$CERT_LIVE" ]]; then
+	say "Certificate already present at $CERT_LIVE — skipping certbot."
+else
+	say "Requesting Let's Encrypt certificate for $FQDN..."
+	backup /etc/nginx/sites-enabled/default
+	certbot --nginx \
+		-d "$FQDN" \
+		-m "$ADMIN_EMAIL" \
+		--agree-tos --non-interactive --redirect
+fi
+systemctl enable --now certbot.timer
+say "Renewal timer: $(systemctl is-active certbot.timer)"
+
+# --- Step d: security headers + rate-limit zones ---------------------------
+say "Installing ${SECURITY_CONF_DST}..."
+if [[ ! -f "$SECURITY_CONF_SRC" ]]; then
+	die "Missing template: $SECURITY_CONF_SRC (run from albert-ai-sandbox repo)."
+fi
+backup "$SECURITY_CONF_DST"
+install -m 0644 "$SECURITY_CONF_SRC" "$SECURITY_CONF_DST"
+nginx -t
+systemctl reload nginx
+
+# --- Step e: fail2ban ------------------------------------------------------
+say "Configuring fail2ban jails..."
+JAIL_FILE="/etc/fail2ban/jail.d/albert.local"
+backup "$JAIL_FILE"
+cat > "$JAIL_FILE" <<'F2B'
+# Albert sandbox fail2ban overrides. Managed by scripts/setup-tls.sh.
+[DEFAULT]
+bantime  = 1h
+findtime = 10m
+maxretry = 5
+backend  = systemd
+
+[sshd]
+enabled  = true
+port     = ssh
+mode     = aggressive
+
+[nginx-http-auth]
+enabled  = true
+
+[nginx-limit-req]
+enabled  = true
+filter   = nginx-limit-req
+logpath  = /var/log/nginx/error.log
+maxretry = 10
+findtime = 10m
+bantime  = 1h
+F2B
+systemctl enable fail2ban >/dev/null
+systemctl restart fail2ban
+sleep 1
+say "Active jails: $(fail2ban-client status 2>/dev/null | awk -F: '/Jail list/{print $2}' | xargs)"
+
+# --- Step f: SSH hardening (with lockout safety) ---------------------------
+say "Hardening sshd (key-only, no password auth)..."
+SSHD_DROPIN="/etc/ssh/sshd_config.d/10-albert-hardening.conf"
+AUTH_KEYS_OK=0
+for h in /root /home/*; do
+	ak="$h/.ssh/authorized_keys"
+	if [[ -s "$ak" ]]; then
+		AUTH_KEYS_OK=1
+		break
+	fi
+done
+if [[ "$AUTH_KEYS_OK" -ne 1 ]]; then
+	warn "No non-empty authorized_keys found. Writing drop-in BUT NOT reloading sshd to prevent lockout."
+	warn "Review $SSHD_DROPIN, install your public key, then run: sshd -t && systemctl reload ssh"
+	RELOAD_SSH=0
+else
+	RELOAD_SSH=1
+fi
+backup "$SSHD_DROPIN"
+cat > "$SSHD_DROPIN" <<'SSH'
+# Albert sandbox SSH hardening. Managed by scripts/setup-tls.sh.
+PasswordAuthentication no
+PermitRootLogin prohibit-password
+KbdInteractiveAuthentication no
+SSH
+if [[ "$RELOAD_SSH" -eq 1 ]]; then
+	sshd -t
+	systemctl reload ssh
+	say "sshd reloaded with hardened config."
+fi
+
+# --- Step g: unattended-upgrades -------------------------------------------
+say "Enabling unattended-upgrades..."
+cat > /etc/apt/apt.conf.d/20auto-upgrades <<'AU'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::AutocleanInterval "7";
+AU
+systemctl enable --now unattended-upgrades >/dev/null
+
+# --- Summary ---------------------------------------------------------------
+say "============================================================"
+say "Host hardening complete."
+say ""
+say "Next steps:"
+say "  1. Deploy albert-ai-sandbox code to its install dir."
+say "  2. Run 'sudo bash install.sh' to (re)install services."
+say "  3. Rotate API keys: 'albert-api-key-manager' — any old key that"
+say "     traversed plain HTTP must be considered compromised."
+say "  4. systemctl start albert-container-manager nginx albert-inactivity-watcher.timer"
+say ""
+say "Backups for this run are in $BACKUP_DIR"


### PR DESCRIPTION
# Security hardening for sandbox-1.novista.ch and the albert-ai-sandbox stack

Closes the findings from the 2026-04-13 audit in
`.context/security-audit-sandbox-1.novista.ch.md`. Scope is audit phases
**1, 2 and 4** — grundlegende Absicherung, Härtung, Betrieb. Container-internal
hardening (Phase 3: Dockerfile sudo, capabilities, image slimming) is
deliberately out of scope because it can break Chrome/Playwright and
deserves its own brainstorm.

The code changes in this PR were **developed, deployed and end-to-end
verified on the live host** before this PR was opened. The host
currently runs with this branch applied and the client-side agorum
integration has been verified green against it. See §Verification below.

---

## Summary

| Theme | What changes |
|---|---|
| File service | Path-traversal fix, opt-in bearer-token auth, tighter permissions |
| Manager API | Loopback bind (127.0.0.1), `/health` requires auth, `/manager/` rate-limited via nginx |
| SQL injection | Fix unquoted heredoc in `lookup_api_key_id_python` |
| VNC + file-service secrets | Per-container random VNC password and file-service bearer token, returned to API clients once |
| Public URLs | `urls.*` in REST responses now use `ALBERT_PUBLIC_URL` (https://fqdn) instead of `http://<ip>/…` |
| Host hardening | New `scripts/setup-tls.sh` + `nginx/albert-security.conf` template: Let's Encrypt, ufw, fail2ban, SSH key-only, unattended-upgrades, ALBERT_PUBLIC_URL drop-in |
| Install tooling | `install.sh` and `nginx-manager.sh` learn about certbot's TLS server block, so `/manager/` and `/<name>/` work over HTTPS after TLS is enabled |
| Chore | `.gitignore` |

---

## Commits

The branch carries **8 thematic commits**, each describing a complete
end state. There is no backtracking — every commit can be reviewed
in isolation without reading later commits.

1. **`34d2ceb` chore: add .gitignore for python caches, editor files, local context**
   - Excludes `__pycache__`, virtualenvs, editor/OS metadata, `.context/`, runtime artifacts.

2. **`f99df70` security(file-service): path traversal fix + opt-in bearer auth**
   - `download_file` and `upload_file` resolve via `os.path.realpath` and reject anything outside `UPLOAD_DIR` (catches symlink escapes too). Always active.
   - Upload directory permissions tightened from `0o777/0o666` to `0o755/0o644`.
   - Bearer token via `FILE_SERVICE_TOKEN` env: when set, enforced with `hmac.compare_digest`. When unset, `require_token()` returns None and the endpoints behave like the legacy open service. Existing clients work unchanged; future client updates can opt in by sending `Authorization: Bearer <token>`.
   - File service binds `0.0.0.0` inside the container so docker port publishing can reach it. Host-side isolation comes from `docker run -p 127.0.0.1:<host>:4000` in commit 5.

3. **`a40b93e` security(manager): bind REST API to loopback and auth /health**
   - `MANAGER_BIND_HOST` env (default `127.0.0.1`) is used by Flask `app.run()`. The systemd unit sets it explicitly.
   - `/health` now runs `require_api_key()` like the rest of the API.
   - `install.sh` `/manager/` proxy block now uses `127.0.0.1:5001` and adds `limit_req zone=albert_manager burst=20 nodelay`. The zone is provisioned by `setup-tls.sh` (commit 7).

4. **`451decf` security(manager): prevent bash-to-python injection in api-key lookup**
   - `lookup_api_key_id_python` used `<<PY` (unquoted heredoc) and interpolated `$hash` directly into Python source. Switched to quoted heredoc `<<'PY'` and pass the value via `LOOKUP_HASH` env variable.

5. **`4afcd37` security(vnc): rotate VNC password and file-service token per container**
   - `albert-ai-sandbox-manager create` generates an 8-char random VNC password and a 128-bit file-service bearer token per container.
   - `docker run` publishes ports on `127.0.0.1` only and threads `VNC_PASSWORD` via env.
   - `nginx-manager.sh create_nginx_config` URL-encodes the VNC password into the noVNC redirect.
   - `common.sh add_to_registry` persists both secrets.
   - `docker/startup.sh` reads `VNC_PASSWORD` (random fallback) and propagates `FILE_SERVICE_TOKEN`.
   - REST create-response includes `vncPassword` and `fileServiceToken` (shown once).
   - This commit also introduces the `public_base_url()` helper because `create_container` is the first call site that consumes it. `start_container` and `show_single_status` adopt it in commit 8.
   - The file-service token is generated and returned to the client but **not** wired into `docker run` (-e) yet, so file-service auth stays in the legacy open mode (see commit 2). One-line follow-up reactivates enforcement when clients are ready.

6. **`8e4c089` fix(install,nginx-manager): include albert-*.conf in certbot TLS block**
   - certbot's `--nginx` plugin creates a second server block scoped to the FQDN with `listen 443 ssl;`. The original include logic only matched `server_name _;`, so the TLS block had no albert routing and `/<container>/` and `/manager/` returned 404 over HTTPS.
   - `install.sh` `ensure_single_include_line` and `ensure_client_max_body_size` now match `server_name ...; # managed by Certbot` as well, drop the single-insert guard, and emit their directive after every matching block. `ensure_client_max_body_size` removes prior occurrences first to stay idempotent.
   - `install.sh` normalization and final verification compare include count to the dynamic target count.
   - `scripts/nginx-manager.sh` (called per container create) mirrors the same matcher logic; `cleanup_nginx_includes` only rewrites on real divergence and writes diagnostics to stderr so they cannot contaminate the JSON channel consumed by `container_manager_service`.
   - Backups written by `cleanup_nginx_includes` go to `/opt/albert-ai-sandbox-manager/nginx/backups/` instead of `sites-enabled/`, where nginx would have loaded them as duplicate configs.

7. **`a5413c3` security(host): add setup-tls.sh for TLS + firewall + fail2ban + SSH**
   - New idempotent host-hardening script and its nginx template. Run once as root, before or after `install.sh`:
     a. Install certbot + plugin, fail2ban, ufw, unattended-upgrades.
     b. ufw allow 22/80/443 (SSH first to avoid lockout), enable.
     c. `certbot --nginx` (skipped if cert already exists), `certbot.timer` for auto-renewal.
     d. Install `/etc/nginx/conf.d/albert-security.conf`: HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, CSP, `server_tokens off`, and the `albert_manager` / `albert_general` rate-limit zones used by the `/manager/` proxy block from commit 3.
     e. fail2ban jails: sshd (aggressive), nginx-http-auth, nginx-limit-req.
     f. SSH drop-in: `PasswordAuthentication no`, `PermitRootLogin prohibit-password`, `KbdInteractiveAuthentication no`. Reload is **skipped automatically** if no `authorized_keys` file exists for any user, to prevent lockout.
     g. `unattended-upgrades` enabled.
   - Modified files are backed up to `/root/albert-hardening/backups/<timestamp>/`.

8. **`85e6617` feat(manager): emit start/status urls via ALBERT_PUBLIC_URL drop-in**
   - `start_container` and `show_single_status` now use the `public_base_url()` helper introduced in commit 5 for both JSON and banner output.
   - `setup-tls.sh` writes `/etc/systemd/system/albert-container-manager.service.d/public-url.conf` with `Environment=ALBERT_PUBLIC_URL=https://<FQDN>`, reloads systemd and restarts the manager service if active. `install.sh` stays FQDN-agnostic — the drop-in lives in `setup-tls.sh` because that is the first point in the lifecycle where the FQDN is known.
   - After this commit every REST response field that contains a public URL points at the canonical `https://<fqdn>/` form. Installations without a public FQDN keep working unchanged because `public_base_url()` falls back to `http://<hostip>/` when `ALBERT_PUBLIC_URL` is unset.

---

## Host changes applied by `setup-tls.sh`

These files are **not** tracked in the repo. They are installed on the
host by `setup-tls.sh`:

- `/etc/nginx/conf.d/albert-security.conf` (from `nginx/albert-security.conf`)
- `/etc/letsencrypt/live/<fqdn>/*` (via certbot)
- `/etc/fail2ban/jail.d/albert.local`
- `/etc/ssh/sshd_config.d/10-albert-hardening.conf`
- `/etc/apt/apt.conf.d/20auto-upgrades`
- `/etc/systemd/system/albert-container-manager.service.d/public-url.conf`
- ufw rules (persisted by ufw itself)

Every modified existing file is backed up to `/root/albert-hardening/backups/<timestamp>/`.

---

## Verification (already performed on the live host)

All checks below were run on `sandbox-1.novista.ch` after the branch
was deployed and `setup-tls.sh` + `install.sh` had been executed. They
were green.

```
curl -I https://sandbox-1.novista.ch/             # 200 + HSTS + no Server version
curl -I http://sandbox-1.novista.ch/              # 301 -> https
curl -sS https://…/manager/health                 # 401 (no bearer)
curl -sS -H "Bearer $KEY" …/manager/health        # 200 {"docker":"up","status":"ok"}
ss -tlnp | grep 5001                              # 127.0.0.1:5001 only
ss -tlnp | grep 7280                              # 127.0.0.1:<filesvc>
curl -m5 http://sandbox-1.novista.ch:5001/health  # Connection timed out (ufw)
ufw status                                        # 22/80/443 allow, rest deny
fail2ban-client status                            # sshd, nginx-http-auth, nginx-limit-req
sshd -T | grep -E "passwordauth|permitrootlogin"  # no / prohibit-password
systemctl show albert-container-manager -p Environment
                                                  # contains ALBERT_PUBLIC_URL=https://sandbox-1.novista.ch
```

End-to-end container lifecycle test:

```
POST /manager/containers          -> 201, response contains vncPassword + fileServiceToken
                                     urls.* all start with https://sandbox-1.novista.ch/
GET  /manager/containers/<name>   -> 200, urls.* all https://sandbox-1.novista.ch/
GET  /<name>/ (HEAD)              -> 301 Location with ?password=<per-container>, not 'albert'
POST /<name>/files/upload         -> 201 without bearer (legacy mode)
POST /<name>/files/upload         -> 201 with bearer (forward-compatible, ignored today)
GET  /<name>/files/download?path=/tmp/albert-files/<uuid>  -> 200 correct content
GET  /<name>/files/download?path=/etc/passwd               -> 403 access denied
DELETE /manager/containers/<name> -> 200 {"deleted": "<name>"}
```

fail2ban reported 13 IPs banned within the first minute of the sshd
jail being active, all from scanners already documented in the audit.

**Client integration verified (2026-04-13/14):** The agorum
`sandbox-upload.js` and `sandbox-download.js` tools work against the
hardened sandbox without any code changes, once `BASE_URL` and the API
key in the tool settings have been updated. Upload and download run in
legacy-open mode; path traversal is blocked.

---

## Known follow-ups (intentionally out of scope)

- **Container-internal hardening (audit phase 3):** Dockerfile still has
  passwordless sudo for the `ubuntu` user; `docker run` still uses
  `--cap-add=SYS_ADMIN` and `--security-opt seccomp=unconfined`. Needs a
  separate brainstorm because it can break Chrome/Playwright.
- **MCP Hub admin password** is still hardcoded to `albert` in
  `docker/startup.sh`. Not in scope here.
- **Activate file-service bearer enforcement:** once the agorum tools
  ship the optional `fileServiceToken` parameter, add the line
  `-e FILE_SERVICE_TOKEN="$filesvc_token"` to `albert-ai-sandbox-manager.sh`
  `create_container`. That flips auth from opt-in to mandatory without
  any other change.

---

## Client integration impact

**API key has been rotated** as part of the incident response. All
clients that used the old `Novista Admin` key must switch to the new
one before testing. See `.context/client-integration-report.md` in the
working tree for the full client-side check list and curl examples.

Breaking changes for clients:

1. All traffic must go to `https://sandbox-1.novista.ch/…` — HTTP now
   redirects, and direct `http://host:5001/` is unreachable.
2. `/manager/health` now requires `Authorization: Bearer <KEY>` (was anonymous).
3. `/<name>/files/download?path=…` only allows paths under
   `/tmp/albert-files/`. Anything else returns 403.
4. VNC password is per-container and returned in the create response;
   hardcoded `albert` no longer works.

Non-breaking, forward-compatible changes:

- The create response now includes `vncPassword` and `fileServiceToken`
  fields. Clients can ignore them today and adopt them when ready.
- File-service auth is prepared but not yet enforced. Clients can
  already send `Authorization: Bearer <fileServiceToken>` — it is
  accepted today. When the server-side switch is flipped, clients that
  already send the header keep working without a code change.
- `urls.*` in create/start/status responses now contain
  `https://sandbox-1.novista.ch/…` directly; clients no longer need to
  rewrite them from `sandboxName` + own base URL.

---

## Commit graph

```
85e6617 feat(manager): emit start/status urls via ALBERT_PUBLIC_URL drop-in
a5413c3 security(host): add setup-tls.sh for TLS + firewall + fail2ban + SSH
8e4c089 fix(install,nginx-manager): include albert-*.conf in certbot TLS block
4afcd37 security(vnc): rotate VNC password and file-service token per container
451decf security(manager): prevent bash-to-python injection in api-key lookup
a40b93e security(manager): bind REST API to loopback and auth /health
f99df70 security(file-service): path traversal fix + opt-in bearer auth
34d2ceb chore: add .gitignore for python caches, editor files, local context
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
